### PR TITLE
Explicitly remove post_buffer on close

### DIFF
--- a/lua/scnvim/_extensions/tmux/init.lua
+++ b/lua/scnvim/_extensions/tmux/init.lua
@@ -87,6 +87,7 @@ function tmux.destroy()
   tmux.close()
   if tmux.post_buffer then
     tmux.post_buffer:close()
+    tmux.post_buffer = nil
   end
 end
 


### PR DESCRIPTION
Think this is actually all that's needed to fix #3 

Done some testing locally and multiple starts/stops in combination with toggling the tmux window seems to work fine